### PR TITLE
set default value for timestamp fields to CURRENT_TIMESTAMP

### DIFF
--- a/Blueprints/schema-create-main.sql
+++ b/Blueprints/schema-create-main.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS <table-name> (
     `user_updated` INT UNSIGNED DEFAULT 0,
     `date_start` TIMESTAMP NULL,
     `date_end` TIMESTAMP NULL,
-    `created_at` TIMESTAMP,
-    `updated_at` TIMESTAMP,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY(id)
 ) ENGINE = MyISAM DEFAULT CHARSET=utf8;

--- a/Blueprints/schema-create-mc.sql
+++ b/Blueprints/schema-create-mc.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS <table-name>_mc (
     `collection_mappings` LONGTEXT NOT NULL,
     `user_created` INT UNSIGNED DEFAULT 0,
     `user_updated` INT UNSIGNED DEFAULT 0,
-    `updated_at` TIMESTAMP,
-    `created_at` TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     UNIQUE KEY(collection_name)
 ) ENGINE = MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Since MySQL 5.7 SQL mode "NO_ZERO_DATE" is enabled by default. That means date fields which are not nullable need a default value ("0000-00-00" is not allowed). Therefore we set the default value to CURRENT_TIMESTAMP so - unless specifically defined in the insert statement - the current timestamp will be used. I guess that makes sense for both `created_at` and `updated_at`.